### PR TITLE
Include missing grant key within the JWT token which was giving 401 e…

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ app.get('/token', function(request, response) {
     // on a given device
     var ipmGrant = new IpMessagingGrant({
         serviceSid: process.env.TWILIO_IPM_SERVICE_SID,
+        pushCredentialSid: 'CRe9c5eff29e744709d7df875f8a797bf0',
         endpointId: endpointId
     });
 


### PR DESCRIPTION
Fix 401 error on start that is happening in ipm-quickstart demo apps.

See issue that users have experienced: https://github.com/TwilioDevEd/ipm-quickstart-php/issues/3